### PR TITLE
Multiple code improvements - squid:S1444, squid:ClassVariableVisibilityCheck, squid:S3008

### DIFF
--- a/app/src/main/java/com/huangzj/simplewheelview/view/WheelStyle.java
+++ b/app/src/main/java/com/huangzj/simplewheelview/view/WheelStyle.java
@@ -17,27 +17,27 @@ public class WheelStyle {
     /**
      * Wheel Style Hour
      */
-    public static int STYLE_HOUR = 1;
+    public static final int STYLE_HOUR = 1;
     /**
      * Wheel Style Minute
      */
-    public static int STYLE_MINUTE = 2;
+    public static final int STYLE_MINUTE = 2;
     /**
      * Wheel Style Year
      */
-    public static int STYLE_YEAR = 3;
+    public static final int STYLE_YEAR = 3;
     /**
      * Wheel Style Month
      */
-    public static int STYLE_MONTH = 4;
+    public static final int STYLE_MONTH = 4;
     /**
      * Wheel Style Day
      */
-    public static int STYLE_DAY = 5;
+    public static final int STYLE_DAY = 5;
     /**
      * Wheel Style Light Time
      */
-    public static int STYLE_LIGHT_TIME = 7;
+    public static final int STYLE_LIGHT_TIME = 7;
 
     public static List<String> getItemList(Context context, int Style) {
         if (Style == STYLE_HOUR) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1444 - "public static" fields should be constant.
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
squid:S3008 - Static non-final field names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1444
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
https://dev.eclipse.org/sonar/rules/show/squid:S3008
Please let me know if you have any questions.
George Kankava
