### PR TITLE
Multiple code improvements - squid:S1067, squid:S1848, squid:S2131, squid:S1118, squid:S00114, squid:S1213

### DIFF
--- a/app/src/main/java/com/huangzj/simplewheelview/dialog/SelectDateDialog.java
+++ b/app/src/main/java/com/huangzj/simplewheelview/dialog/SelectDateDialog.java
@@ -67,7 +67,7 @@ public class SelectDateDialog extends BaseDialog {
         dayWheel = (WheelView) dialogView.findViewById(R.id.select_date_day_wheel);
 
         yearWheel.setWheelStyle(WheelStyle.STYLE_YEAR);
-        yearWheel.setOnSelectListener(new WheelView.onSelectListener() {
+        yearWheel.setOnSelectListener(new WheelView.SelectListener() {
             @Override
             public void onSelect(int index, String text) {
                 selectYear = index + WheelStyle.minYear;
@@ -76,7 +76,7 @@ public class SelectDateDialog extends BaseDialog {
         });
 
         monthWheel.setWheelStyle(WheelStyle.STYLE_MONTH);
-        monthWheel.setOnSelectListener(new WheelView.onSelectListener() {
+        monthWheel.setOnSelectListener(new WheelView.SelectListener() {
             @Override
             public void onSelect(int index, String text) {
                 selectMonth = index + 1;

--- a/app/src/main/java/com/huangzj/simplewheelview/util/SizeConvertUtil.java
+++ b/app/src/main/java/com/huangzj/simplewheelview/util/SizeConvertUtil.java
@@ -9,6 +9,7 @@ import android.content.Context;
  */
 public class SizeConvertUtil {
 
+    private SizeConvertUtil() {}
 
     public static int dpTopx(Context context, float dp) {
         final float scale = context.getResources().getDisplayMetrics().density;

--- a/app/src/main/java/com/huangzj/simplewheelview/view/WheelStyle.java
+++ b/app/src/main/java/com/huangzj/simplewheelview/view/WheelStyle.java
@@ -14,6 +14,9 @@ import java.util.List;
  */
 public class WheelStyle {
 
+    public static final int minYear = 1980;
+    public static final int maxYear = 2020;
+
     /**
      * Wheel Style Hour
      */
@@ -39,6 +42,8 @@ public class WheelStyle {
      */
     public static int STYLE_LIGHT_TIME = 7;
 
+    private WheelStyle() {}
+
     public static List<String> getItemList(Context context, int Style) {
         if (Style == STYLE_HOUR) {
             return createHourString();
@@ -53,9 +58,8 @@ public class WheelStyle {
         } else if (Style == STYLE_LIGHT_TIME) {
             return createWeekString(context);
         } else {
-            new IllegalArgumentException("style is illegal");
+            throw new IllegalArgumentException("style is illegal");
         }
-        return null;
     }
 
     private static List<String> createHourString() {
@@ -74,13 +78,10 @@ public class WheelStyle {
         return wheelString;
     }
 
-    public static final int minYear = 1980;
-    public static final int maxYear = 2020;
-
     private static List<String> createYearString() {
         List<String> wheelString = new ArrayList<>();
         for (int i = minYear; i <= maxYear; i++) {
-            wheelString.add("" + i);
+            wheelString.add(Integer.toString(i));
         }
         return wheelString;
     }

--- a/app/src/main/java/com/huangzj/simplewheelview/view/WheelView.java
+++ b/app/src/main/java/com/huangzj/simplewheelview/view/WheelView.java
@@ -72,7 +72,7 @@ public class WheelView extends View {
      */
     private float mMoveLen = 0;
     private boolean isInit = false;
-    private onSelectListener mSelectListener;
+    private SelectListener mSelectListener;
     private Timer timer;
     private MyTimerTask mTask;
 
@@ -112,7 +112,7 @@ public class WheelView extends View {
         init(context);
     }
 
-    public void setOnSelectListener(onSelectListener listener) {
+    public void setOnSelectListener(SelectListener listener) {
         mSelectListener = listener;
     }
 
@@ -388,7 +388,7 @@ public class WheelView extends View {
         }
     }
 
-    public interface onSelectListener {
+    public interface SelectListener {
         void onSelect(int index, String text);
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1848 - Objects should not be created to be dropped immediately without being used.
squid:S2131 - Primitives should not be boxed just for "String" conversion.
squid:S1118 - Utility classes should not have public constructors.
squid:S00114 - Interface names should comply with a naming convention.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1848
https://dev.eclipse.org/sonar/rules/show/squid:S2131
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S00114
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava
